### PR TITLE
Fix channel ID syntax

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,9 +16,9 @@ runs:
     - name: Send to Slack
       uses: slackapi/slack-github-action@v1.24.0
       with:
+        channel-id: ${{ inputs.slack_channel }}
         payload: |
           {
-            "channel-id": "${{ inputs.slack_channel }}",
             "text": "${{ github.repository }} - ${{ github.workflow}} #${{ github.run_number }} - ${{ inputs.status }}\n`${{ github.job }}` job triggered by ${{ github.event_name }} in `${{ github.ref_name }}` branch/tag",
             "blocks": [
               {


### PR DESCRIPTION
This fixes `channel-id` syntax, see example use [here](https://github.com/slackapi/slack-github-action#usage-1).